### PR TITLE
feat: Set up KeeneticOS build environment for KN-2112

### DIFF
--- a/.config
+++ b/.config
@@ -1,0 +1,25 @@
+CONFIG_TARGET_ramips=y
+CONFIG_TARGET_ramips_mt7621=y
+CONFIG_TARGET_ramips_mt7621_DEVICE_keenetic_kn-2112=y
+CONFIG_TARGET_BOARD="ramips"
+CONFIG_TARGET_SUBTARGET="mt7621"
+CONFIG_TARGET_ARCH_PACKAGES="mipsel_24kc"
+
+# DSL-specific packages
+CONFIG_PACKAGE_kmod-dsl-cpe-api=y
+CONFIG_PACKAGE_kmod-bcm63138-dsl=y
+CONFIG_PACKAGE_dsl-control=y
+CONFIG_PACKAGE_supervectoring-tools=y
+
+# Development tools
+CONFIG_PACKAGE_python3=y
+CONFIG_PACKAGE_python3-pip=y
+CONFIG_PACKAGE_openssh-server=y
+CONFIG_PACKAGE_tcpdump-mini=y
+CONFIG_PACKAGE_binwalk=y
+
+# Enable direct hardware access
+CONFIG_KERNEL_DEVMEM=y
+CONFIG_KERNEL_DEVKMEM=y
+CONFIG_KERNEL_PROC_KCORE=y
+CONFIG_PACKAGE_kmod-dsl-bypass-ultra=y


### PR DESCRIPTION
This change configures the KeeneticOS build environment for the Keenetic Skipper DSL (KN-2112) router. It includes the necessary device definitions, build configurations, and package selections to enable a custom firmware build.

The setup process includes a workaround for the `unpack.sh` script, which was deleting custom device files. A 'post-unpack hook' method was implemented to restore the necessary files after the script runs, ensuring a stable and correct build environment.