### PR TITLE
Implement G.hs Message Injection for DSL Handshake Manipulation

### DIFF
--- a/src/ghs_packet_crafter.py
+++ b/src/ghs_packet_crafter.py
@@ -1,0 +1,119 @@
+import logging
+from scapy.all import Packet, ByteField, FieldLenField, StrLenField, PacketListField, NoPayload
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class NPar(Packet):
+    """
+    Represents a Name/Parameter (NPar) field, a basic TLV-like structure.
+    """
+    name = "NPar"
+    fields_desc = [
+        ByteField("npar_id", 0),
+        FieldLenField("npar_len", None, length_of="npar_payload", fmt="B"),
+        StrLenField("npar_payload", b"", length_from=lambda p: p.npar_len)
+    ]
+
+class SPar(Packet):
+    """
+    Represents a Standard Parameter (SPar) field. This implementation uses a
+    manual dissection pattern, which is the robust way to handle a list of
+    packets where the length is defined in bytes.
+    """
+    name = "SPar"
+    fields_desc = [
+        ByteField("spar_id", 0),
+        # The length of the raw bytes of the NPar list
+        FieldLenField("spar_len", None, length_of="raw_npars", fmt="!H"),
+        # A field to hold the raw bytes of the NPar list
+        StrLenField("raw_npars", b"", length_from=lambda p: p.spar_len),
+    ]
+
+    def post_dissect(self, s):
+        """
+        After dissecting the raw bytes, parse them into a list of NPar objects.
+        This list is stored in a new attribute, `npar_list`.
+        """
+        self.npar_list = []
+        data = self.raw_npars
+        while data:
+            npar = NPar(data)
+            self.npar_list.append(npar)
+            if isinstance(npar.payload, NoPayload):
+                break
+            data = npar.payload.load
+        return s
+
+class GHS_Message(Packet):
+    """
+    Represents a top-level G.hs message.
+    """
+    name = "G.hs Message"
+    fields_desc = [
+        ByteField("sync_flag", 0x00),
+        ByteField("message_type", 0),
+        PacketListField("spar_list", [], SPar)
+    ]
+
+def craft_fake_cl_message(
+    vendor_id: bytes = b'KTC_FAKE',
+    profile_35b: bool = True,
+    force_vectoring: bool = True
+) -> bytes:
+    """
+    High-level function to craft a fake G.hs Capabilities List (CL) message.
+    This version uses the robust manual dissection pattern.
+
+    Args:
+        vendor_id: A byte string for the fake vendor ID.
+        profile_35b: If True, advertises support for VDSL2 profile 35b.
+        force_vectoring: If True, advertises support for G.vector (vectoring).
+
+    Returns:
+        The raw bytes of the crafted G.hs message.
+    """
+    logging.info(f"Crafting fake CL message: 35b={profile_35b}, Vectoring={force_vectoring}")
+
+    npar_list = []
+    if profile_35b:
+        npar_list.append(NPar(npar_id=2, npar_payload=b'\x80'))
+        logging.info("Injecting VDSL2 Profile 35b capability.")
+    if force_vectoring:
+        npar_list.append(NPar(npar_id=3, npar_payload=b'\x01'))
+        logging.info("Injecting G.vector capability.")
+    if vendor_id:
+        npar_list.append(NPar(npar_id=1, npar_payload=vendor_id))
+        logging.info(f"Injecting Vendor ID: {vendor_id.decode(errors='ignore')}")
+
+    # Manually build the NPar list into a raw byte string
+    raw_npars_bytes = b"".join(bytes(n) for n in npar_list)
+
+    # Instantiate SPar using the 'raw_npars' field, which is in fields_desc
+    spar_container = SPar(spar_id=2, raw_npars=raw_npars_bytes)
+
+    ghs_pkt = GHS_Message(message_type=2, spar_list=[spar_container])
+    return bytes(ghs_pkt)
+
+if __name__ == '__main__':
+    # --- Example of crafting a fake CL message ---
+    print("--- Example: Crafting a fake capabilities message ---")
+    fake_cl_packet = craft_fake_cl_message(
+        vendor_id=b'ACME_MODEM',
+        profile_35b=True,
+        force_vectoring=True
+    )
+
+    print("\nRaw packet bytes:")
+    print(fake_cl_packet.hex())
+
+    # --- Verify the structure ---
+    print("\nScapy dissection of the crafted packet:")
+    decoded_pkt = GHS_Message(fake_cl_packet)
+    # To see the manually dissected list:
+    if decoded_pkt.spar_list:
+        print("\nManually dissected NPars:")
+        for npar in decoded_pkt.spar_list[0].npar_list:
+            npar.show()
+    else:
+        decoded_pkt.show()

--- a/tests/test_ghs_packet_crafter.py
+++ b/tests/test_ghs_packet_crafter.py
@@ -1,0 +1,97 @@
+import unittest
+from scapy.all import raw
+
+from src.ghs_packet_crafter import craft_fake_cl_message, GHS_Message, NPar
+
+class TestGHSPacketCrafter(unittest.TestCase):
+    """
+    Unit tests for the G.hs packet crafting library. These tests have been
+    updated to validate the corrected logic where all parameters are grouped
+    into a single SPar container.
+    """
+
+    def test_craft_default_fake_cl_message(self):
+        """
+        Tests a default CL message with all capabilities enabled.
+        It should contain one SPar with three NPars.
+        """
+        packet_bytes = craft_fake_cl_message(
+            vendor_id=b'TEST',
+            profile_35b=True,
+            force_vectoring=True
+        )
+        decoded_pkt = GHS_Message(packet_bytes)
+
+        self.assertEqual(len(decoded_pkt.spar_list), 1, "Should contain exactly one SPar")
+
+        spar = decoded_pkt.spar_list[0]
+        self.assertEqual(spar.spar_id, 2, "SPar ID should be 2 (non-standard)")
+        self.assertEqual(len(spar.npar_list), 3, "SPar should contain three NPars")
+
+        npar_payloads = {n.npar_id: n.npar_payload for n in spar.npar_list}
+        self.assertIn(1, npar_payloads)
+        self.assertEqual(npar_payloads[1], b'TEST')
+        self.assertIn(2, npar_payloads)
+        self.assertEqual(npar_payloads[2], b'\x80')
+        self.assertIn(3, npar_payloads)
+        self.assertEqual(npar_payloads[3], b'\x01')
+
+    def test_craft_cl_message_no_vectoring(self):
+        """
+        Tests that disabling vectoring correctly produces two NPars (profile and vendor).
+        """
+        packet_bytes = craft_fake_cl_message(
+            profile_35b=True,
+            force_vectoring=False
+        )
+        decoded_pkt = GHS_Message(packet_bytes)
+        spar = decoded_pkt.spar_list[0]
+
+        self.assertEqual(len(spar.npar_list), 2, "SPar should contain two NPars")
+        npar_ids = {n.npar_id for n in spar.npar_list}
+        self.assertNotIn(3, npar_ids, "Vectoring NPar should be omitted")
+        self.assertIn(2, npar_ids)
+        self.assertIn(1, npar_ids)
+
+    def test_craft_cl_message_no_35b(self):
+        """
+        Tests that disabling profile 35b correctly produces two NPars (vectoring and vendor).
+        """
+        packet_bytes = craft_fake_cl_message(
+            profile_35b=False,
+            force_vectoring=True
+        )
+        decoded_pkt = GHS_Message(packet_bytes)
+        spar = decoded_pkt.spar_list[0]
+
+        self.assertEqual(len(spar.npar_list), 2, "SPar should contain two NPars")
+        npar_ids = {n.npar_id for n in spar.npar_list}
+        self.assertNotIn(2, npar_ids, "Profile 35b NPar should be omitted")
+        self.assertIn(3, npar_ids)
+        self.assertIn(1, npar_ids)
+
+    def test_packet_byte_level_correctness(self):
+        """
+        Performs a byte-level check of a known packet structure to ensure
+        the crafter generates the exact bytes expected.
+        """
+        # Expected structure: Non-standard SPar (ID 2) with one NPar for profile 35b
+        expected_bytes = b'\x00\x02\x02\x00\x03\x02\x01\x80'
+
+        crafted_bytes = craft_fake_cl_message(
+            vendor_id=None,
+            profile_35b=True,
+            force_vectoring=False
+        )
+
+        self.assertEqual(crafted_bytes, expected_bytes)
+
+        # Decode for programmatic verification
+        decoded_pkt = GHS_Message(crafted_bytes)
+        self.assertEqual(decoded_pkt.spar_list[0].spar_id, 2)
+        self.assertEqual(len(decoded_pkt.spar_list[0].npar_list), 1)
+        self.assertEqual(decoded_pkt.spar_list[0].npar_list[0].npar_id, 2)
+        self.assertEqual(decoded_pkt.spar_list[0].npar_list[0].npar_payload, b'\x80')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new feature for crafting and injecting custom G.hs (G.994.1) handshake messages to manipulate the DSL connection at the protocol level.

The core of this feature is a new packet crafting library in `src/ghs_packet_crafter.py`, which uses Scapy to define the structure of G.hs messages. This library allows for the creation of custom packets to advertise fake CPE capabilities, override VDSL2 profile selection (e.g., force 35b), and inject custom vendor information.

A new `GHSHandshakeSpoofer` class in `src/spoofing.py` utilizes this library to build the malicious packets. To enable sending these custom frames, a raw packet injection mechanism has been added to the `EntwareSSHInterface`. This mechanism works by uploading and executing a temporary Python script on the remote device, which uses Scapy's `L2Socket` to inject the raw packet onto the specified network interface.

The new functionality is demonstrated in `main.py`, and comprehensive unit tests have been added in `tests/test_ghs_packet_crafter.py` to ensure the correctness and reliability of the packet crafting logic. This includes tests for various capability combinations and byte-level verification of the generated packets.

This change directly addresses the user's request to implement G.hs message injection capabilities, providing a powerful tool for advanced DSL line testing and manipulation.