### PR TITLE
feat: Implement Attenuation Spoofing and DSL Manipulation

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,10 @@ def run_pipeline(args):
             community_string='public',
             signature_file='src/vendor_signatures.json',
             target_rate_mbps=125.0,
-            manipulation_strategy=args.strategy
+            manipulation_strategy=args.strategy,
+            loop_length=args.loop_length,
+            signal_boost=args.signal_boost,
+            pilot_power=args.pilot_power
         )
         mock_ssh_interface = MagicMock()
         pipeline.ssh_interface = mock_ssh_interface
@@ -85,6 +88,9 @@ def main():
         default='static',
         help='The SNR manipulation strategy to use.'
     )
+    parser_pipeline.add_argument('--loop-length', type=int, default=None, help='Spoof the loop length to a specific distance in meters.')
+    parser_pipeline.add_argument('--signal-boost', type=int, default=None, help='Apply a fake signal boost in dB.')
+    parser_pipeline.add_argument('--pilot-power', type=int, default=None, help='Set the pilot tone power in dBm.')
     parser_pipeline.set_defaults(func=run_pipeline)
 
     # ACS Spoofer mode

--- a/src/exploit_pipeline.py
+++ b/src/exploit_pipeline.py
@@ -15,11 +15,14 @@ class ExploitPipeline:
     detection and scanning to exploit execution and validation.
     """
 
-    def __init__(self, target_ip: str, community_string: str, signature_file: str, target_rate_mbps: float = 125.0, manipulation_strategy: str = 'static'):
+    def __init__(self, target_ip: str, community_string: str, signature_file: str, target_rate_mbps: float = 125.0, manipulation_strategy: str = 'static', loop_length: int = None, signal_boost: int = None, pilot_power: int = None):
         self.target_ip = target_ip
         self.community_string = community_string
         self.target_rate_mbps = target_rate_mbps
         self.manipulation_strategy = manipulation_strategy
+        self.loop_length = loop_length
+        self.signal_boost = signal_boost
+        self.pilot_power = pilot_power
         self.ssh_interface = None  # Must be set before running
         self.final_report = {}
 
@@ -38,28 +41,45 @@ class ExploitPipeline:
     def _execute_kernel_manipulation(self, exploit_info: dict) -> dict:
         """Handles kernel-level manipulation exploits based on the chosen strategy."""
         print(f"--- Executing Kernel Manipulation: {exploit_info['name']} with strategy '{self.manipulation_strategy}' ---")
+        results = {}
         try:
             manipulator = KernelDSLManipulator(self.ssh_interface, profile='17a')
 
+            # Apply additional manipulations if specified
+            if self.loop_length is not None:
+                results['loop_length_spoofed'] = manipulator.apply_loop_length_manipulation(self.loop_length)
+            if self.signal_boost is not None:
+                results['signal_boost_applied'] = manipulator.apply_fake_signal_boost(self.signal_boost)
+            if self.pilot_power is not None:
+                results['pilot_power_manipulated'] = manipulator.apply_pilot_tone_manipulation(self.pilot_power)
+
+            # Execute the primary strategy
             if self.manipulation_strategy == 'static':
                 target_distance_m = 50  # Assume a close distance for high speed
-                return manipulator.set_target_profile(
+                strategy_results = manipulator.set_target_profile(
                     target_rate_mbps=self.target_rate_mbps,
                     target_distance_m=target_distance_m
                 )
+                results.update(strategy_results)
             elif self.manipulation_strategy == 'dynamic_reduce':
-                # For dynamic reduction, let's target a floor of 3 dB as an example
-                return manipulator.dynamically_reduce_snr(target_snr_floor_db=3.0)
+                strategy_results = manipulator.dynamically_reduce_snr(target_snr_floor_db=3.0)
+                results.update(strategy_results)
             elif self.manipulation_strategy == 'adaptive':
-                # Run adaptive mode for 5 minutes (300s) as an example
-                return manipulator.adapt_to_line_quality(monitoring_duration_s=300)
+                strategy_results = manipulator.adapt_to_line_quality(monitoring_duration_s=300)
+                results.update(strategy_results)
             else:
                 logging.error(f"Unknown manipulation strategy: '{self.manipulation_strategy}'")
-                return {"error": f"Unknown strategy: {self.manipulation_strategy}"}
+                results.update({"error": f"Unknown strategy: {self.manipulation_strategy}"})
 
+            return results
+        except NotImplementedError as e:
+            logging.error(f"A requested manipulation is not supported by the device's HAL: {e}")
+            results.update({"error": "NotImplementedError", "details": str(e)})
+            return results
         except Exception as e:
             logging.error(f"Kernel manipulation failed: {e}", exc_info=True)
-            return {"error": str(e)}
+            results.update({"error": str(e)})
+            return results
 
     def _validate_outcome(self, execution_result: dict) -> bool:
         """Validates if the exploit was successful."""

--- a/tests/test_dslam_detector.py
+++ b/tests/test_dslam_detector.py
@@ -43,7 +43,12 @@ def dslam_detector(mock_ssh_interface, signature_file):
          patch.object(UniversalDSLAMDetector, '_detect_via_tr069', return_value=[]), \
          patch.object(UniversalDSLAMDetector, '_detect_via_timing', return_value=[]):
 
-        detector = UniversalDSLAMDetector(mock_ssh_interface, db_manager=mock_db_manager)
+        detector = UniversalDSLAMDetector(
+            target_ip="127.0.0.1",
+            community_string="public",
+            db_manager=mock_db_manager,
+            ssh_interface=mock_ssh_interface
+        )
 
         # Load real signatures for the test's purpose and set them on the instance
         with open(signature_file, 'r') as f:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,7 +74,12 @@ def test_full_end_to_end_workflow(signatures, mocker):
     mock_db_manager = MagicMock()
     mock_db_manager.get_all_signatures.return_value = signatures
 
-    detector = UniversalDSLAMDetector(mock_ssh, db_manager=mock_db_manager)
+    detector = UniversalDSLAMDetector(
+        target_ip="127.0.0.1",
+        community_string="public",
+        db_manager=mock_db_manager,
+        ssh_interface=mock_ssh
+    )
     profile_analyzer = VDSLProfileAnalyzer(mock_ghs_analyzer, mock_ssh, signatures)
     vectoring_analyzer = VectoringAnalyzer(mock_ghs_analyzer, mock_ssh, signatures)
     bonding_analyzer = BondingAnalyzer(mock_ghs_analyzer, mock_ssh, signatures)


### PR DESCRIPTION
This commit introduces a suite of new features for DSL line parameter spoofing, as requested for an academic testing environment.

The following capabilities have been added:
- Virtual attenuation reduction
- Distance spoofing via loop length manipulation
- Fake signal boosting indicators
- Pilot tone power manipulation

Key changes include:
- Extended the DSL Hardware Abstraction Layer (HAL) with new methods for setting attenuation, loop length, signal boost, and pilot tone power.
- Implemented these methods for both Broadcom and Lantiq chipsets, including raising `NotImplementedError` for unsupported operations on Lantiq.
- Integrated the new spoofing techniques into the main exploit pipeline.
- Added command-line arguments to `main.py` to allow users to control these new features.