### PR TITLE
feat: Add framework for DSL line diagnostics

### DIFF
--- a/src/keenetic_dsl_interface.py
+++ b/src/keenetic_dsl_interface.py
@@ -228,6 +228,55 @@ class DslHalBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def run_selt(self) -> dict:
+        """
+        Initiates a Single-Ended Line Test (SELT) and returns the results.
+        SELT provides information about line length and potential issues.
+        Returns:
+            A dictionary containing SELT results, such as line length and fault locations.
+        """
+        pass
+
+    @abstractmethod
+    def run_melt(self) -> dict:
+        """
+        Initiates a Metallic Line Test (MELT) to check physical line characteristics.
+        This test usually requires the line to be in a non-operational state.
+        Returns:
+            A dictionary with measurements like voltage, resistance, and capacitance.
+        """
+        pass
+
+    @abstractmethod
+    def run_delt(self) -> dict:
+        """
+        Initiates a Dual-Ended Line Test (DELT).
+        This is a comprehensive test that requires coordination with the DSLAM.
+        Returns:
+            A dictionary containing detailed line state information from both ends.
+        """
+        pass
+
+    @abstractmethod
+    def get_qln_data(self) -> dict[int, float] | None:
+        """
+        Retrieves the Quiet Line Noise (QLN) measurement on a per-tone basis.
+        This represents the noise floor when the line is idle.
+        Returns:
+            A dictionary mapping tone index to noise power in dBm/Hz, or None on failure.
+        """
+        pass
+
+    @abstractmethod
+    def get_hlog_data(self) -> dict[int, float] | None:
+        """
+        Retrieves the Hlog data (per-tone channel characteristics/attenuation).
+        Returns:
+            A dictionary mapping tone index to attenuation in dB, or None on failure.
+        """
+        pass
+
 
 class BroadcomDslHal(DslHalBase):
     """
@@ -542,6 +591,39 @@ class BroadcomDslHal(DslHalBase):
         logging.info(f"Successfully set bit-swap state to {state}.")
         return True
 
+    def run_selt(self) -> dict:
+        logging.warning("SELT is not yet implemented for Broadcom HAL.")
+        # Command might be: f"{self.driver_path} diag --selt"
+        return {"status": "unsupported", "message": "SELT not implemented for this hardware."}
+
+    def run_melt(self) -> dict:
+        logging.warning("MELT is not yet implemented for Broadcom HAL.")
+        # Command might be: f"{self.driver_path} diag --melt"
+        return {"status": "unsupported", "message": "MELT not implemented for this hardware."}
+
+    def run_delt(self) -> dict:
+        logging.warning("DELT is not yet implemented for Broadcom HAL.")
+        # Command might be: f"{self.driver_path} diag --delt"
+        return {"status": "unsupported", "message": "DELT not implemented for this hardware."}
+
+    def get_qln_data(self) -> dict[int, float] | None:
+        if not self.driver_path:
+            logging.error("Broadcom driver command not found.")
+            return None
+        logging.warning("QLN data retrieval is not yet implemented for Broadcom HAL, returning mock data.")
+        # Hypothetical command: f"{self.driver_path} info --show --qln"
+        # Returning mock data for tones 0-10
+        return {i: -135.0 + (i % 5) for i in range(10)}
+
+    def get_hlog_data(self) -> dict[int, float] | None:
+        if not self.driver_path:
+            logging.error("Broadcom driver command not found.")
+            return None
+        logging.warning("Hlog data retrieval is not yet implemented for Broadcom HAL, returning mock data.")
+        # Hypothetical command: f"{self.driver_path} info --show --hlog"
+        # Returning mock data for tones 0-10
+        return {i: 5.0 + i * 0.5 for i in range(10)}
+
 
 class LantiqDslHal(DslHalBase):
     """
@@ -816,6 +898,39 @@ class LantiqDslHal(DslHalBase):
             return False
         logging.info(f"Successfully set bit-swap state to {'enabled' if enabled else 'disabled'}.")
         return True
+
+    def run_selt(self) -> dict:
+        logging.warning("SELT is not yet implemented for Lantiq HAL.")
+        # Command might be: f"echo 1 > {self.driver_path}/diag/selt_trigger"
+        return {"status": "unsupported", "message": "SELT not implemented for this hardware."}
+
+    def run_melt(self) -> dict:
+        logging.warning("MELT is not yet implemented for Lantiq HAL.")
+        # Command might be: f"echo 1 > {self.driver_path}/diag/melt_trigger"
+        return {"status": "unsupported", "message": "MELT not implemented for this hardware."}
+
+    def run_delt(self) -> dict:
+        logging.warning("DELT is not yet implemented for Lantiq HAL.")
+        # Command might be: f"echo 1 > {self.driver_path}/diag/delt_trigger"
+        return {"status": "unsupported", "message": "DELT not implemented for this hardware."}
+
+    def get_qln_data(self) -> dict[int, float] | None:
+        if not self.driver_path:
+            logging.error("Lantiq driver path not found.")
+            return None
+        logging.warning("QLN data retrieval is not yet implemented for Lantiq HAL, returning mock data.")
+        # Hypothetical command: f"cat {self.driver_path}/diag/qln_data"
+        # Returning mock data for tones 0-10
+        return {i: -138.0 + (i % 5) for i in range(10)}
+
+    def get_hlog_data(self) -> dict[int, float] | None:
+        if not self.driver_path:
+            logging.error("Lantiq driver path not found.")
+            return None
+        logging.warning("Hlog data retrieval is not yet implemented for Lantiq HAL, returning mock data.")
+        # Hypothetical command: f"cat {self.driver_path}/diag/hlog_data"
+        # Returning mock data for tones 0-10
+        return {i: 4.0 + i * 0.6 for i in range(10)}
 
 
 # Maps Keenetic models to their corresponding DSL HAL implementation.

--- a/src/line_diagnostics.py
+++ b/src/line_diagnostics.py
@@ -1,0 +1,131 @@
+import logging
+from src.keenetic_dsl_interface import DslHalBase
+from src.advanced_dsl_physics import AdvancedDSLPhysics, FLAT_NOISE_FLOOR_DBM_HZ
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class LineDiagnostics:
+    """
+    Provides a suite of tools for running DSL line diagnostics.
+    """
+    def __init__(self, hal: DslHalBase, profile: str = '17a'):
+        """
+        Initializes the LineDiagnostics class.
+
+        Args:
+            hal: An instance of a DSL Hardware Abstraction Layer (HAL).
+            profile: The VDSL2 profile to use for physics calculations.
+        """
+        self.hal = hal
+        self.physics = AdvancedDSLPhysics(profile=profile)
+        logging.info(f"Line Diagnostics initialized for profile {profile}.")
+
+    def run_selt(self) -> dict:
+        """
+        Runs a Single-Ended Line Test (SELT) and returns the results.
+        """
+        logging.info("Requesting SELT from HAL...")
+        results = self.hal.run_selt()
+        logging.info(f"SELT results received: {results}")
+        return results
+
+    def run_melt(self) -> dict:
+        """
+        Runs a Metallic Line Test (MELT) and returns the results.
+        """
+        logging.info("Requesting MELT from HAL...")
+        results = self.hal.run_melt()
+        logging.info(f"MELT results received: {results}")
+        return results
+
+    def run_delt(self) -> dict:
+        """
+        Runs a Dual-Ended Line Test (DELT) and returns the results.
+        """
+        logging.info("Requesting DELT from HAL...")
+        results = self.hal.run_delt()
+        logging.info(f"DELT results received: {results}")
+        return results
+
+    def analyze_qln(self, noise_margin_db: float = 6.0) -> dict:
+        """
+        Analyzes Quiet Line Noise (QLN) data from the HAL.
+
+        Args:
+            noise_margin_db: The threshold above the theoretical noise floor to flag as anomalous.
+
+        Returns:
+            A dictionary containing the QLN analysis.
+        """
+        logging.info("Requesting QLN data from HAL...")
+        qln_data = self.hal.get_qln_data()
+
+        if qln_data is None:
+            logging.error("Failed to retrieve QLN data from HAL.")
+            return {"status": "error", "message": "Could not get QLN data."}
+
+        anomalous_tones = {}
+        for tone, noise_level in qln_data.items():
+            if noise_level > (FLAT_NOISE_FLOOR_DBM_HZ + noise_margin_db):
+                anomalous_tones[tone] = {
+                    "measured_noise": noise_level,
+                    "noise_floor": FLAT_NOISE_FLOOR_DBM_HZ,
+                    "anomaly_db": noise_level - FLAT_NOISE_FLOOR_DBM_HZ,
+                }
+
+        analysis = {
+            "status": "completed",
+            "average_noise_dbm_hz": sum(qln_data.values()) / len(qln_data) if qln_data else 0,
+            "anomalous_tones_found": len(anomalous_tones),
+            "anomalous_tones": anomalous_tones,
+            "raw_data": qln_data,
+        }
+        logging.info(f"QLN analysis complete. Found {len(anomalous_tones)} anomalous tones.")
+        return analysis
+
+    def analyze_hlog(self, estimated_distance_m: int = 300, deviation_threshold_db: float = 10.0) -> dict:
+        """
+        Analyzes Hlog (channel characteristics) data from the HAL.
+
+        Args:
+            estimated_distance_m: The estimated line length in meters for the theoretical model.
+            deviation_threshold_db: The dB threshold to flag a deviation as significant.
+
+        Returns:
+            A dictionary containing the Hlog analysis.
+        """
+        logging.info("Requesting Hlog data from HAL...")
+        hlog_data = self.hal.get_hlog_data()
+
+        if hlog_data is None:
+            logging.error("Failed to retrieve Hlog data from HAL.")
+            return {"status": "error", "message": "Could not get Hlog data."}
+
+        theoretical_attenuation = self.physics.model_attenuation_per_tone(distance_m=estimated_distance_m)
+        tone_indices = self.physics.get_tone_indices()
+
+        # Ensure we have a 1-to-1 mapping of tone index to theoretical attenuation
+        theoretical_hlog = dict(zip(tone_indices, theoretical_attenuation))
+
+        deviating_tones = {}
+        for tone, measured_atten in hlog_data.items():
+            if tone in theoretical_hlog:
+                theoretical_atten = theoretical_hlog[tone]
+                deviation = abs(measured_atten - theoretical_atten)
+                if deviation > deviation_threshold_db:
+                    deviating_tones[tone] = {
+                        "measured_attenuation": measured_atten,
+                        "theoretical_attenuation": theoretical_atten,
+                        "deviation_db": deviation,
+                    }
+
+        analysis = {
+            "status": "completed",
+            "estimated_distance_m": estimated_distance_m,
+            "deviating_tones_found": len(deviating_tones),
+            "deviating_tones": deviating_tones,
+            "raw_data": hlog_data,
+        }
+        logging.info(f"Hlog analysis complete. Found {len(deviating_tones)} deviating tones.")
+        return analysis


### PR DESCRIPTION
This change introduces a new `diagnostics` mode to the application, providing a framework for running various DSL line tests.

The new mode is accessible via the command line and supports the following tests:
- SELT (Single-Ended Line Testing)
- MELT (Metallic Line Testing)
- DELT (Dual-Ended Line Testing)
- QLN (Quiet Line Noise) analysis
- Hlog (Channel Characteristics) analysis

Key changes include:
- A new `src/line_diagnostics.py` module containing the core logic for the diagnostic tests.
- An extension of the `DslHalBase` class with new abstract methods for each diagnostic test.
- Placeholder implementations of the new HAL methods in the `BroadcomDslHal` and `LantiqDslHal` classes, which return mock data.
- A new `diagnostics` subcommand in `main.py` to provide a user-facing interface for the new features.

The implementation is structured to allow for the easy integration of hardware-specific commands once they become available.