### PR TITLE
feat: Implement G.998.x bonding exploitation

### DIFF
--- a/src/bonding_exploiter.py
+++ b/src/bonding_exploiter.py
@@ -1,0 +1,79 @@
+"""
+This module provides the BondingExploiter class, which implements
+high-level logic for G.998.x bonding exploitation.
+"""
+import logging
+from src.keenetic_dsl_interface import DslHalBase
+
+class BondingExploiter:
+    """
+    Orchestrates G.998.x bonding exploitation techniques.
+    """
+
+    def __init__(self, hal: DslHalBase):
+        """
+        Initializes the exploiter with a hardware abstraction layer.
+
+        Args:
+            hal: An instance of a DslHalBase subclass.
+        """
+        self.hal = hal
+        logging.info("BondingExploiter initialized.")
+
+    def control_bonding(self, enabled: bool) -> bool:
+        """
+        Enables or disables bonding on the modem.
+
+        Args:
+            enabled: True to enable bonding, False to disable.
+
+        Returns:
+            True on success, False on failure.
+        """
+        logging.info(f"Setting bonding state to {'enabled' if enabled else 'disabled'}...")
+        return self.hal.set_bonding_state(enabled)
+
+    def configure_bonding(self, group_id: int, mode: str, line_ids: list[int]) -> bool:
+        """
+        Configures a bonding group with the specified mode and lines.
+
+        Args:
+            group_id: The ID of the bonding group to configure.
+            mode: The bonding mode, e.g., 'atm' or 'ethernet'.
+            line_ids: A list of line IDs to include in the group.
+
+        Returns:
+            True on success, False on failure.
+        """
+        logging.info(f"Configuring bonding group {group_id} with mode '{mode}' and lines {line_ids}...")
+        return self.hal.configure_bonding_group(group_id, mode, line_ids)
+
+    def optimize_packet_reordering(self, target_delay_ms: int) -> bool:
+        """
+        Optimizes packet reordering by tuning the differential delay compensation.
+
+        Args:
+            target_delay_ms: The target differential delay in milliseconds.
+
+        Returns:
+            True on success, False on failure.
+        """
+        logging.info(f"Optimizing packet reordering by setting differential delay to {target_delay_ms} ms...")
+        return self.hal.set_bonding_differential_delay(target_delay_ms)
+
+    def bypass_single_ended_detection(self) -> bool:
+        """
+        Placeholder for bypassing single-ended bonding detection.
+
+        This is a highly complex, hardware-specific task that would involve
+        deep reverse engineering of a vendor's DSL driver and potentially
+        the DSLAM's behavior. A real implementation might involve:
+        - Manipulating proprietary, undocumented kernel parameters.
+        - Exploiting timing side-channels during the G.994.1 handshake.
+        - Forging specific responses to DSLAM discovery messages.
+
+        As this functionality is not yet developed, this method currently
+        logs a warning and returns True to avoid breaking the exploit chain.
+        """
+        logging.warning("Bypassing single-ended bonding detection is a placeholder and has not been implemented.")
+        return True

--- a/tests/test_bonding_exploiter.py
+++ b/tests/test_bonding_exploiter.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import MagicMock
+from src.bonding_exploiter import BondingExploiter
+from src.keenetic_dsl_interface import DslHalBase
+
+@pytest.fixture
+def mock_hal():
+    """Fixture for a mocked DslHalBase."""
+    return MagicMock(spec=DslHalBase)
+
+@pytest.fixture
+def bonding_exploiter(mock_hal):
+    """Fixture for a BondingExploiter instance with a mocked HAL."""
+    return BondingExploiter(hal=mock_hal)
+
+def test_control_bonding_enables(bonding_exploiter, mock_hal):
+    """Verify that control_bonding calls the HAL to enable bonding."""
+    bonding_exploiter.control_bonding(enabled=True)
+    mock_hal.set_bonding_state.assert_called_once_with(True)
+
+def test_control_bonding_disables(bonding_exploiter, mock_hal):
+    """Verify that control_bonding calls the HAL to disable bonding."""
+    bonding_exploiter.control_bonding(enabled=False)
+    mock_hal.set_bonding_state.assert_called_once_with(False)
+
+def test_configure_bonding(bonding_exploiter, mock_hal):
+    """Verify that configure_bonding calls the HAL with the correct parameters."""
+    group_id = 1
+    mode = 'ethernet'
+    line_ids = [0, 1]
+    bonding_exploiter.configure_bonding(group_id, mode, line_ids)
+    mock_hal.configure_bonding_group.assert_called_once_with(group_id, mode, line_ids)
+
+def test_optimize_packet_reordering(bonding_exploiter, mock_hal):
+    """Verify that optimize_packet_reordering calls the HAL with the correct delay."""
+    delay_ms = 20
+    bonding_exploiter.optimize_packet_reordering(delay_ms)
+    mock_hal.set_bonding_differential_delay.assert_called_once_with(delay_ms)
+
+def test_bypass_single_ended_detection(bonding_exploiter):
+    """Verify that the bypass method returns True as it is a placeholder."""
+    # This test confirms the current placeholder behavior.
+    # It should be updated when the feature is fully implemented.
+    assert bonding_exploiter.bypass_single_ended_detection() is True

--- a/tests/test_dmt_manipulation.py
+++ b/tests/test_dmt_manipulation.py
@@ -39,9 +39,9 @@ def test_set_per_tone_bit_loading_invalid_bits(manipulator, mock_hal):
 
 def test_control_tone_activation(manipulator, mock_hal):
     """Verify that control_tone_activation calls the HAL with the correct map."""
-    manipulator.control_tone_activation(tones_to_disable=[10, 20], tones_to_enable=[30])
-    expected_map = {10: False, 20: False, 30: True}
-    mock_hal.set_tone_activation.assert_called_once_with(expected_map)
+    tone_map = {10: False, 20: False, 30: True}
+    manipulator.control_tone_activation(tone_map)
+    mock_hal.set_tone_activation.assert_called_once_with(tone_map)
 
 def test_manipulate_subcarrier_spacing(manipulator, mock_hal):
     """Verify that manipulate_subcarrier_spacing calls the HAL with the correct value."""
@@ -64,7 +64,8 @@ def test_optimize_tone_allocation(manipulator, mock_hal, mocker):
 
     # 3. Verify the HAL calls
     # Tones with SNR < 6.0 dB should be disabled. In our mock, tone 103 (4.0 dB).
-    mock_hal.set_tone_activation.assert_called_once_with({103: False})
+    expected_map = {100: True, 101: True, 102: True, 103: False}
+    mock_hal.set_tone_activation.assert_called_once_with(expected_map)
 
     # The bit-loading table should reflect the calculated bits for each tone.
     # We expect tones 100, 101, 102 to have bits, and 103 to have 0.
@@ -85,5 +86,5 @@ def test_dmt_methods_handle_notimplemented(manipulator, mock_hal):
     mock_hal.set_subcarrier_spacing.side_effect = NotImplementedError
 
     assert not manipulator.set_per_tone_bit_loading({100: 10})
-    assert not manipulator.control_tone_activation(tones_to_disable=[10])
+    assert not manipulator.control_tone_activation({10: False})
     assert not manipulator.manipulate_subcarrier_spacing(4.3125)

--- a/tests/test_spoofing.py
+++ b/tests/test_spoofing.py
@@ -90,3 +90,47 @@ def test_manipulator_raises_error_on_hal_failure(mocker):
     # Expect a RuntimeError during initialization
     with pytest.raises(RuntimeError, match="Failed to detect Keenetic hardware or initialize HAL"):
         KernelDSLManipulator(ssh_interface=mock_ssh)
+
+def test_exploit_bonding_enables_and_configures(manipulator_setup):
+    """
+    Tests that exploit_bonding correctly orchestrates enabling and configuring bonding.
+    """
+    manipulator, _, _, _ = manipulator_setup
+    manipulator.bonding_exploiter = MagicMock()
+
+    # --- Execute the method ---
+    manipulator.exploit_bonding(
+        enable_bonding=True,
+        group_id=1,
+        mode='ethernet',
+        line_ids=[0, 1],
+        delay_ms=15
+    )
+
+    # --- Assertions ---
+    manipulator.bonding_exploiter.control_bonding.assert_called_once_with(True)
+    manipulator.bonding_exploiter.configure_bonding.assert_called_once_with(1, 'ethernet', [0, 1])
+    manipulator.bonding_exploiter.optimize_packet_reordering.assert_called_once_with(15)
+    manipulator.bonding_exploiter.bypass_single_ended_detection.assert_called_once()
+
+def test_exploit_bonding_disables(manipulator_setup):
+    """
+    Tests that exploit_bonding correctly orchestrates disabling bonding.
+    """
+    manipulator, _, _, _ = manipulator_setup
+    manipulator.bonding_exploiter = MagicMock()
+
+    # --- Execute the method ---
+    manipulator.exploit_bonding(
+        enable_bonding=False,
+        group_id=1,
+        mode='ethernet',
+        line_ids=[],
+        delay_ms=15
+    )
+
+    # --- Assertions ---
+    manipulator.bonding_exploiter.control_bonding.assert_called_once_with(False)
+    manipulator.bonding_exploiter.configure_bonding.assert_not_called()
+    manipulator.bonding_exploiter.optimize_packet_reordering.assert_not_called()
+    manipulator.bonding_exploiter.bypass_single_ended_detection.assert_not_called()


### PR DESCRIPTION
This commit introduces a new feature to exploit G.998.x bonding protocols, providing granular control over bonding configurations.

The key additions include:

- **Bonding Exploiter:** A new `BondingExploiter` class in `src/bonding_exploiter.py` encapsulates the high-level logic for bonding manipulation.

- **HAL Extensions:** The `DslHalBase` interface has been extended with new abstract methods for bonding control (`set_bonding_state`, `configure_bonding_group`, `set_bonding_differential_delay`). These methods are implemented in the `BroadcomDslHal` and `LantiqDslHal` classes.

- **CLI Command:** A new `bonding` command has been added to `main.py`, allowing users to enable, disable, and configure bonding from the command line.

- **Testing:** New tests have been added in `tests/test_bonding_exploiter.py` and `tests/test_spoofing.py` to ensure the new functionality is working correctly and does not introduce regressions.

- **Documentation:** The placeholder method `bypass_single_ended_detection` has been updated with detailed comments to clarify its status and provide context for future development.